### PR TITLE
Added control for damage

### DIFF
--- a/src/main/java/com/jinqinxixi/trinketsandbaubles/items/baubles/PoisonStoneItem.java
+++ b/src/main/java/com/jinqinxixi/trinketsandbaubles/items/baubles/PoisonStoneItem.java
@@ -74,16 +74,18 @@ public class PoisonStoneItem extends ModifiableBaubleItem {
 
     @SubscribeEvent
     public static void onLivingHurt(LivingHurtEvent event) {
-        if (event.getSource().getEntity() instanceof LivingEntity attacker) {
-            LivingEntity target = event.getEntity();
+        if (ModConfig.POISON_STONE_ACTIVATE_DAMAGE_EVENT.get()) {                // We add a boolean to control when this event fires or not
+            if (event.getSource().getEntity() instanceof LivingEntity attacker) {
+                LivingEntity target = event.getEntity();
 
-            // 处理中毒效果
-            onAttack(attacker, target);
+                // 处理中毒效果
+                onAttack(attacker, target);
 
-            // 处理额外伤害
-            float multiplier = getExtraDamageMultiplier(attacker, target);
-            if (multiplier > 1.0F) {
-                event.setAmount(event.getAmount() * multiplier);
+                // 处理额外伤害
+                float multiplier = getExtraDamageMultiplier(attacker, target);
+                if (multiplier > 1.0F) {
+                    event.setAmount(event.getAmount() * multiplier);
+                }
             }
         }
     }


### PR DESCRIPTION
While this might look useless, its useful for other mod devs that would want to handle this damage bonus in specific calculations Please add those controls in your mods when increasing damage done, I use a library for DamageControl and i would prefer to handle it there to allow a desired output. I would like to explain in detail about why this is important but language barriers are kinda of difficult so please help us with this.

I will try to explain. When you subscribe any event like LivingHurtEvent the order in which this method is called is not always clear, even if you use prioritys it might end up in a position you dont know, this can lead to damage increases or reductions in ways you cant really know until you play test it with other mods.
I created a Damage Control Library that allows me and all my mods to precisely calculate and define where your damage increase is gonna be added, that way if my mod increases damage first by +5 then your mod increases it by 2x or 200%, then i can decide if my +5 damage increase is also increased by your mod or not. I would like you to use my library but i dont want to give you more trouble so adding a control to turn off the calculations should do enough.
Just in case you are curious, here is the library Im using:
https://github.com/Kettle5000/Progressive-Mechanics-Library/tree/main