### PR TITLE
Moved Logic to another place

### DIFF
--- a/src/main/java/com/jinqinxixi/trinketsandbaubles/items/baubles/DragonsEyeFireItem.java
+++ b/src/main/java/com/jinqinxixi/trinketsandbaubles/items/baubles/DragonsEyeFireItem.java
@@ -13,10 +13,27 @@ import top.theillusivec4.curios.api.SlotContext;
 import javax.annotation.Nullable;
 import java.util.List;
 
+@Mod.EventBusSubscriber
 public class DragonsEyeFireItem extends DragonsEyeItem {
 
     public DragonsEyeFireItem(Properties properties) {
         super(properties);
+    }
+
+    @SubscribeEvent
+    public static void onLivingHurt(LivingAttackEvent event) {   //LivingAttackEvent fires before LivingHurtEvent, I think you will prefer this.
+        if (event.getEntity() instanceof Player player && !player.level().isClientSide) {
+            // 检查是否是龙火伤害
+            if (event.getSource().is(ResourceKey.create(Registries.DAMAGE_TYPE,
+                    new ResourceLocation("iceandfire", "dragon_fire")))) {
+
+                // 检查玩家是否有这个效果
+                if (CuriosApi.getCuriosHelper().findEquippedCurio(ModItem.DRAGON_FIRE_EYES.get(), player).isPresent()) {
+                    // 取消伤害
+                    event.setCanceled(true);
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
There is no need to use a new Fire Resistance Effect when there is already one, you can use this logic inside this item since is this item that makes you inmune to dragon breath.
I dont think there is need to do that with the rest of the dragons. Only with Fire Dragons.
Now we should only have one Fire Resistance, instead of two.